### PR TITLE
Fixed WiFi Client Mode with WEP protocol

### DIFF
--- a/api/module.php
+++ b/api/module.php
@@ -208,12 +208,27 @@ class NetworkingPlus extends SystemModule
 
 		exec('[ ! -z "$(wifi detect)" ] && wifi detect > /etc/config/wireless');
 
+        $key = $this->request->key;
+
 		$uciID = $this->getUciID($interface);
 		$security = $this->request->ap->security;
 		switch ($security) {
 			case 'Open':
 				$encryption = "none";
 				break;
+
+			case 'WEP Open/Shared (WEP-40, WEP-104)':
+                $encryption = "wep";
+
+                $key_hex = '';
+
+                for($i=0; $i<strlen($key); $i++){
+                    $key_hex .= dechex(ord($key[$i]));
+                }
+
+                $key = $key_hex;
+                break;
+
 
 			case 'WPA (TKIP)':
 			case 'WPA PSK (TKIP)':
@@ -272,7 +287,7 @@ class NetworkingPlus extends SystemModule
 		$this->uciSet("wireless.@wifi-iface[{$uciID}].mode", 'sta');
 		$this->uciSet("wireless.@wifi-iface[{$uciID}].ssid", $this->request->ap->ssid);
 		$this->uciSet("wireless.@wifi-iface[{$uciID}].encryption", $encryption);
-		$this->uciSet("wireless.@wifi-iface[{$uciID}].key", $this->request->key);
+		$this->uciSet("wireless.@wifi-iface[{$uciID}].key", $key);
 
 		$radioID = $this->getRadioID($interface);
 		if ($radioID === false) {


### PR DESCRIPTION
In the section Networking of the pineapple application is possible connect the interface wlan1 to a wifi but this method only works with WPA encryption, using WEP protocol simply doesn't connect.

This happens because the api of the module 'networking' (/pineapple/modules/Networking/api/module.php), in the function connectToAP(), is only designed to modify the wireless configuration file (/etc/config/wireless) in the case that the encryption be open or differents types of WPA.

This is not exactly a bug, simply the function wasn't designed to all cases but I think that is really interesting at least have the WEP protocol because is unusual but unfortunately is used and is a weakness that in a pentest can be used to provide internet to our device.

To fix this issue I modified the file '/pineapple/modules/Networking/api/module.php' adding to the switch the case of WEP protocol, because it's neccessary modify the variable of configuration 'encrypt', in this case is ' web', and the key should be the hexdump of the string. The changes done can see it in the next images: https://ibb.co/dkKeXQ || https://ibb.co/cjMF6k